### PR TITLE
[ISSUE-005] Wire left-click toggle to AppState and SleepManager

### DIFF
--- a/Neverdie/Neverdie.xcodeproj/project.pbxproj
+++ b/Neverdie/Neverdie.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A10005 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20007 /* AppState.swift */; };
 		A10006 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20008 /* Protocols.swift */; };
 		A10007 /* SleepManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20009 /* SleepManager.swift */; };
+		A10008 /* StatusBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000A /* StatusBarController.swift */; };
 		A10010 /* NeverdieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20010 /* NeverdieTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -38,6 +39,7 @@
 		A20007 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		A20008 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		A20009 /* SleepManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepManager.swift; sourceTree = "<group>"; };
+		A2000A /* StatusBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
 		A20011 /* NeverdieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NeverdieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -78,6 +80,7 @@
 				A20007 /* AppState.swift */,
 				A20008 /* Protocols.swift */,
 				A20009 /* SleepManager.swift */,
+				A2000A /* StatusBarController.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -205,6 +208,7 @@
 				A10005 /* AppState.swift in Sources */,
 				A10006 /* Protocols.swift in Sources */,
 				A10007 /* SleepManager.swift in Sources */,
+				A10008 /* StatusBarController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Neverdie/Sources/NeverdieApp.swift
+++ b/Neverdie/Sources/NeverdieApp.swift
@@ -1,21 +1,44 @@
 import SwiftUI
+import AppKit
 import os
+
+/// Application delegate for handling lifecycle events.
+///
+/// Creates and owns the AppState, SleepManager, and StatusBarController.
+/// Manages the NSStatusItem directly for left-click toggle support.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var appState: AppState!
+    private var sleepManager: SleepManager!
+    private var statusBarController: StatusBarController!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        sleepManager = SleepManager()
+        appState = AppState(sleepManager: sleepManager)
+        statusBarController = StatusBarController(appState: appState)
+        Logger.lifecycle.info("Neverdie app launched")
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        appState?.cleanup()
+        Logger.lifecycle.info("Neverdie app terminating")
+    }
+}
 
 /// Main entry point for the Neverdie menu bar app.
 ///
 /// Neverdie prevents macOS system sleep while Claude Code is running.
 /// It lives in the menu bar only (no Dock icon via LSUIElement=true).
 ///
-/// The menu bar icon shows a sleeping zombie when OFF.
-/// Falls back to "ND" text if the zombie asset is missing.
+/// Uses NSApplicationDelegateAdaptor to wire AppDelegate for lifecycle
+/// management and NSStatusItem-based menu bar control.
 @main
 struct NeverdieApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     var body: some Scene {
-        MenuBarExtra {
-            Text("Neverdie")
-                .padding()
-        } label: {
-            MenuBarIconView()
+        // Use Settings scene as a no-op since we manage the menu bar via NSStatusItem
+        Settings {
+            EmptyView()
         }
     }
 }
@@ -24,6 +47,7 @@ struct NeverdieApp: App {
 ///
 /// Shows the sleeping zombie icon from the asset catalog,
 /// with fallback to "ND" text if the asset is not available.
+/// Kept for potential reuse in SwiftUI contexts.
 struct MenuBarIconView: View {
     var body: some View {
         if let zombieImage = NSImage(named: "ZombieSleep") {

--- a/Neverdie/Sources/StatusBarController.swift
+++ b/Neverdie/Sources/StatusBarController.swift
@@ -1,0 +1,125 @@
+import AppKit
+import SwiftUI
+import os
+
+/// Manages the NSStatusItem for the Neverdie menu bar app.
+///
+/// StatusBarController handles:
+/// - Left-click: Toggle Neverdie mode via AppState
+/// - Icon switching between OFF (zombie sleep) and ON (bolt.fill placeholder)
+/// - VoiceOver announcements on state changes
+/// - AppKit-level NSStatusItem management
+final class StatusBarController {
+    private var statusItem: NSStatusItem
+    private let appState: AppState
+    private let logger = Logger.ui
+
+    // MARK: - Icon Images
+
+    /// Static sleeping zombie icon for OFF state.
+    private lazy var offIcon: NSImage? = {
+        guard let img = NSImage(named: "ZombieSleep") else {
+            logger.warning("ZombieSleep asset not found, will use fallback")
+            return nil
+        }
+        img.isTemplate = true
+        img.size = NSSize(width: 18, height: 18)
+        return img
+    }()
+
+    /// Placeholder ON icon (SF Symbol bolt.fill until animation is wired).
+    private lazy var onIcon: NSImage? = {
+        let img = NSImage(systemSymbolName: "bolt.fill", accessibilityDescription: "Neverdie active")
+        img?.isTemplate = true
+        img?.size = NSSize(width: 18, height: 18)
+        return img
+    }()
+
+    // MARK: - Init
+
+    /// Create a StatusBarController.
+    /// - Parameter appState: The shared AppState instance.
+    init(appState: AppState) {
+        self.appState = appState
+        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+
+        setupButton()
+        updateIcon()
+        logger.info("StatusBarController initialized")
+    }
+
+    // MARK: - Setup
+
+    private func setupButton() {
+        guard let button = statusItem.button else { return }
+
+        button.target = self
+        button.action = #selector(handleClick(_:))
+        button.sendAction(on: [.leftMouseUp])
+
+        // Accessibility
+        updateAccessibility()
+    }
+
+    // MARK: - Click Handling
+
+    @objc private func handleClick(_ sender: NSStatusBarButton) {
+        appState.toggle()
+        updateIcon()
+        updateAccessibility()
+        announceStateChange()
+        logger.info("Toggle triggered via left-click, isActive=\(self.appState.isActive)")
+    }
+
+    // MARK: - Icon Management
+
+    /// Update the menu bar icon based on current state.
+    func updateIcon() {
+        guard let button = statusItem.button else { return }
+
+        if appState.isActive {
+            if let icon = onIcon {
+                button.image = icon
+            } else {
+                button.image = nil
+                button.title = "ND"
+            }
+        } else {
+            if let icon = offIcon {
+                button.image = icon
+            } else {
+                button.image = nil
+                button.title = "ND"
+            }
+        }
+    }
+
+    // MARK: - Accessibility
+
+    private func updateAccessibility() {
+        guard let button = statusItem.button else { return }
+        let state = appState.isActive ? "ON" : "OFF"
+        button.setAccessibilityLabel("Neverdie -- sleep prevention \(state)")
+    }
+
+    /// Post a VoiceOver announcement when state changes.
+    private func announceStateChange() {
+        let state = appState.isActive ? "ON" : "OFF"
+        let announcement = "Neverdie \(state)"
+
+        let userInfo: [NSAccessibility.NotificationUserInfoKey: Any] = [
+            NSAccessibility.NotificationUserInfoKey(rawValue: NSAccessibility.NotificationUserInfoKey.announcement.rawValue): announcement,
+            NSAccessibility.NotificationUserInfoKey(rawValue: NSAccessibility.NotificationUserInfoKey.priority.rawValue): NSAccessibilityPriorityLevel.high.rawValue
+        ]
+        NSAccessibility.post(
+            element: statusItem.button as Any,
+            notification: .announcementRequested,
+            userInfo: userInfo
+        )
+    }
+
+    // MARK: - Public API
+
+    /// Get the NSStatusItem for menu wiring.
+    var item: NSStatusItem { statusItem }
+}

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -79,8 +79,7 @@ def test_neverdie_app_swift_exists():
     assert app_swift.exists(), "NeverdieApp.swift not found"
     content = app_swift.read_text()
     assert "@main" in content, "NeverdieApp.swift must have @main attribute"
-    assert "MenuBarExtra" in content, "NeverdieApp.swift must use MenuBarExtra"
-    assert "MenuBarExtra" in content, "Should use MenuBarExtra for menu bar"
+    assert "NeverdieApp" in content, "NeverdieApp struct must be defined"
 
 
 def test_logger_extensions_exist():

--- a/tests/test_toggle_wiring.py
+++ b/tests/test_toggle_wiring.py
@@ -1,0 +1,108 @@
+"""Tests for ISSUE-005: Wire left-click toggle to AppState and SleepManager.
+
+Verifies the StatusBarController, AppDelegate, and toggle wiring.
+"""
+
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+XCODE_PROJECT = PROJECT_ROOT / "Neverdie" / "Neverdie.xcodeproj"
+SOURCES = PROJECT_ROOT / "Neverdie" / "Sources"
+
+
+def test_status_bar_controller_exists():
+    """StatusBarController.swift exists."""
+    sbc = SOURCES / "StatusBarController.swift"
+    assert sbc.exists(), "StatusBarController.swift not found"
+
+
+def test_status_bar_controller_interface():
+    """StatusBarController has required methods."""
+    content = (SOURCES / "StatusBarController.swift").read_text()
+    assert "class StatusBarController" in content
+    assert "handleClick" in content, "Must handle left-click"
+    assert "updateIcon" in content, "Must update icon on state change"
+    assert "announceStateChange" in content, "Must announce for VoiceOver"
+
+
+def test_left_click_toggle_wired():
+    """Left click is wired to AppState.toggle()."""
+    content = (SOURCES / "StatusBarController.swift").read_text()
+    assert "appState.toggle()" in content, "Click must call appState.toggle()"
+    assert "leftMouseUp" in content, "Must handle left mouse up"
+
+
+def test_icon_switching():
+    """Icon switches between OFF and ON states."""
+    content = (SOURCES / "StatusBarController.swift").read_text()
+    assert "offIcon" in content, "Must have OFF icon"
+    assert "onIcon" in content, "Must have ON icon"
+    assert "ZombieSleep" in content, "OFF icon should be ZombieSleep"
+
+
+def test_voiceover_announcement():
+    """VoiceOver announcement is posted on toggle."""
+    content = (SOURCES / "StatusBarController.swift").read_text()
+    assert "announcementRequested" in content, "Must post VoiceOver announcement"
+    assert "Neverdie" in content
+
+
+def test_accessibility_label():
+    """Accessibility label updates with state."""
+    content = (SOURCES / "StatusBarController.swift").read_text()
+    assert "setAccessibilityLabel" in content or "accessibilityLabel" in content
+    assert "sleep prevention" in content
+
+
+def test_app_delegate_exists():
+    """AppDelegate class exists in NeverdieApp.swift."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "class AppDelegate" in content
+    assert "NSApplicationDelegate" in content
+
+
+def test_app_delegate_creates_appstate():
+    """AppDelegate creates AppState with SleepManager."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "SleepManager()" in content, "Must create SleepManager"
+    assert "AppState(" in content, "Must create AppState"
+    assert "StatusBarController(" in content, "Must create StatusBarController"
+
+
+def test_app_delegate_cleanup():
+    """applicationWillTerminate calls cleanup."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "applicationWillTerminate" in content
+    assert "cleanup()" in content
+
+
+def test_neverdie_app_uses_delegate():
+    """NeverdieApp uses NSApplicationDelegateAdaptor."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "NSApplicationDelegateAdaptor" in content
+
+
+def test_xcodebuild_succeeds():
+    """Project builds with toggle wiring."""
+    result = subprocess.run(
+        [
+            "xcodebuild",
+            "build",
+            "-project",
+            str(XCODE_PROJECT),
+            "-scheme",
+            "Neverdie",
+            "-configuration",
+            "Debug",
+            "-arch",
+            "arm64",
+            "CODE_SIGN_IDENTITY=-",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGNING_ALLOWED=NO",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"xcodebuild failed:\n{result.stderr[-1000:]}"


### PR DESCRIPTION
Closes #9

## Summary
- StatusBarController manages NSStatusItem with left-click toggle
- AppDelegate creates and wires AppState + SleepManager + StatusBarController
- Icon switches between sleeping zombie (OFF) and bolt.fill placeholder (ON)
- VoiceOver announcements on state changes
- Accessibility labels update with state

## Test plan
- [x] StatusBarController has required methods
- [x] Left-click wired to toggle
- [x] Icon switching between states
- [x] VoiceOver and accessibility
- [x] AppDelegate lifecycle wiring
- [x] xcodebuild succeeds
- [x] All 60 tests pass