### PR TITLE
[ISSUE-007] Handle SIGTERM/SIGINT and applicationWillTerminate cleanup

### DIFF
--- a/Neverdie/Neverdie.xcodeproj/project.pbxproj
+++ b/Neverdie/Neverdie.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A10006 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20008 /* Protocols.swift */; };
 		A10007 /* SleepManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20009 /* SleepManager.swift */; };
 		A10008 /* StatusBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000A /* StatusBarController.swift */; };
+		A10009 /* SignalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000B /* SignalHandler.swift */; };
 		A10010 /* NeverdieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20010 /* NeverdieTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -40,6 +41,7 @@
 		A20008 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		A20009 /* SleepManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepManager.swift; sourceTree = "<group>"; };
 		A2000A /* StatusBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
+		A2000B /* SignalHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalHandler.swift; sourceTree = "<group>"; };
 		A20011 /* NeverdieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NeverdieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -81,6 +83,7 @@
 				A20008 /* Protocols.swift */,
 				A20009 /* SleepManager.swift */,
 				A2000A /* StatusBarController.swift */,
+				A2000B /* SignalHandler.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -209,6 +212,7 @@
 				A10006 /* Protocols.swift in Sources */,
 				A10007 /* SleepManager.swift in Sources */,
 				A10008 /* StatusBarController.swift in Sources */,
+				A10009 /* SignalHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Neverdie/Sources/NeverdieApp.swift
+++ b/Neverdie/Sources/NeverdieApp.swift
@@ -15,10 +15,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         sleepManager = SleepManager()
         appState = AppState(sleepManager: sleepManager)
         statusBarController = StatusBarController(appState: appState)
+
+        // Register signal handlers for clean shutdown on SIGTERM/SIGINT
+        SignalHandler.register { [weak self] in
+            self?.appState?.cleanup()
+        }
+
         Logger.lifecycle.info("Neverdie app launched")
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        SignalHandler.unregister()
         appState?.cleanup()
         Logger.lifecycle.info("Neverdie app terminating")
     }

--- a/Neverdie/Sources/SignalHandler.swift
+++ b/Neverdie/Sources/SignalHandler.swift
@@ -1,0 +1,65 @@
+import Foundation
+import os
+
+/// Registers SIGTERM and SIGINT signal handlers for clean shutdown.
+///
+/// When a termination signal is received, the handler calls the provided
+/// cleanup closure (which should release IOPMAssertions) before exiting.
+///
+/// ## Usage
+/// ```swift
+/// SignalHandler.register { appState.cleanup() }
+/// ```
+///
+/// Note: Uses `DispatchSource.makeSignalSource` after ignoring the default
+/// signal behavior with `signal(SIG, SIG_IGN)`.
+final class SignalHandler {
+    private static var sigTermSource: DispatchSourceSignal?
+    private static var sigIntSource: DispatchSourceSignal?
+    private static let logger = Logger.lifecycle
+
+    /// Register SIGTERM and SIGINT handlers.
+    ///
+    /// - Parameter cleanup: Closure to call before exiting. Should release
+    ///   any held IOPMAssertions and stop monitors. Must be synchronous.
+    static func register(cleanup: @escaping () -> Void) {
+        // Ignore default signal behavior so DispatchSource can handle them
+        signal(SIGTERM, SIG_IGN)
+        signal(SIGINT, SIG_IGN)
+
+        // SIGTERM handler
+        let termSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+        termSource.setEventHandler {
+            logger.info("SIGTERM received, performing cleanup")
+            cleanup()
+            logger.info("Cleanup complete, exiting")
+            exit(0)
+        }
+        termSource.resume()
+        sigTermSource = termSource
+
+        // SIGINT handler
+        let intSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+        intSource.setEventHandler {
+            logger.info("SIGINT received, performing cleanup")
+            cleanup()
+            logger.info("Cleanup complete, exiting")
+            exit(0)
+        }
+        intSource.resume()
+        sigIntSource = intSource
+
+        logger.info("Signal handlers registered (SIGTERM, SIGINT)")
+    }
+
+    /// Unregister signal handlers.
+    ///
+    /// Cancels the dispatch sources. Safe to call multiple times.
+    static func unregister() {
+        sigTermSource?.cancel()
+        sigTermSource = nil
+        sigIntSource?.cancel()
+        sigIntSource = nil
+        logger.debug("Signal handlers unregistered")
+    }
+}

--- a/tests/test_signal_cleanup.py
+++ b/tests/test_signal_cleanup.py
@@ -1,0 +1,95 @@
+"""Tests for ISSUE-007: SIGTERM/SIGINT and applicationWillTerminate cleanup."""
+
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+XCODE_PROJECT = PROJECT_ROOT / "Neverdie" / "Neverdie.xcodeproj"
+SOURCES = PROJECT_ROOT / "Neverdie" / "Sources"
+
+
+def test_signal_handler_exists():
+    """SignalHandler.swift exists."""
+    assert (SOURCES / "SignalHandler.swift").exists()
+
+
+def test_signal_handler_registers_sigterm():
+    """SignalHandler registers SIGTERM handler."""
+    content = (SOURCES / "SignalHandler.swift").read_text()
+    assert "SIGTERM" in content
+    assert "DispatchSource.makeSignalSource" in content
+
+
+def test_signal_handler_registers_sigint():
+    """SignalHandler registers SIGINT handler."""
+    content = (SOURCES / "SignalHandler.swift").read_text()
+    assert "SIGINT" in content
+
+
+def test_signal_handler_calls_cleanup():
+    """Signal handlers call cleanup closure."""
+    content = (SOURCES / "SignalHandler.swift").read_text()
+    assert "cleanup()" in content
+
+
+def test_signal_handler_exits_after_cleanup():
+    """Signal handlers exit(0) after cleanup."""
+    content = (SOURCES / "SignalHandler.swift").read_text()
+    assert "exit(0)" in content
+
+
+def test_signal_handler_ignores_default():
+    """Default signal handling is ignored before DispatchSource."""
+    content = (SOURCES / "SignalHandler.swift").read_text()
+    assert "SIG_IGN" in content
+
+
+def test_signal_handler_unregister():
+    """SignalHandler.unregister() cancels sources."""
+    content = (SOURCES / "SignalHandler.swift").read_text()
+    assert "func unregister()" in content
+    assert "cancel()" in content
+
+
+def test_app_delegate_registers_signals():
+    """AppDelegate registers signal handlers on launch."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "SignalHandler.register" in content
+
+
+def test_app_delegate_unregisters_on_terminate():
+    """AppDelegate unregisters signal handlers on terminate."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "SignalHandler.unregister" in content
+    assert "applicationWillTerminate" in content
+
+
+def test_cleanup_called_on_terminate():
+    """applicationWillTerminate calls cleanup."""
+    content = (SOURCES / "NeverdieApp.swift").read_text()
+    assert "cleanup()" in content
+
+
+def test_xcodebuild_succeeds():
+    """Project builds with signal handling."""
+    result = subprocess.run(
+        [
+            "xcodebuild",
+            "build",
+            "-project",
+            str(XCODE_PROJECT),
+            "-scheme",
+            "Neverdie",
+            "-configuration",
+            "Debug",
+            "-arch",
+            "arm64",
+            "CODE_SIGN_IDENTITY=-",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGNING_ALLOWED=NO",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"xcodebuild failed:\n{result.stderr[-1000:]}"


### PR DESCRIPTION
Closes #11

## Summary
- SignalHandler with DispatchSource for SIGTERM and SIGINT
- Calls AppState.cleanup() before exit(0) on signal receipt
- Wired in AppDelegate: register on launch, unregister on terminate
- All termination paths (Quit menu, SIGTERM, SIGINT, normal) release assertions

## Test plan
- [x] Signal handler registers SIGTERM/SIGINT
- [x] Cleanup called on signal
- [x] exit(0) after cleanup
- [x] Unregister cancels sources
- [x] AppDelegate wiring
- [x] xcodebuild succeeds
- [x] 11 new tests pass