### PR TITLE
feat: reactive StatusBarController for clamshell pause

### DIFF
--- a/Neverdie/Neverdie.xcodeproj/project.pbxproj
+++ b/Neverdie/Neverdie.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A10012 /* ClamshellObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20015 /* ClamshellObserver.swift */; };
 		A10013 /* PowerSourceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20016 /* PowerSourceMonitor.swift */; };
 		A10014 /* ClamshellBatteryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20017 /* ClamshellBatteryTests.swift */; };
+		A10015 /* StatusBarClamshellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20018 /* StatusBarClamshellTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		A20015 /* ClamshellObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamshellObserver.swift; sourceTree = "<group>"; };
 		A20016 /* PowerSourceMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerSourceMonitor.swift; sourceTree = "<group>"; };
 		A20017 /* ClamshellBatteryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClamshellBatteryTests.swift; sourceTree = "<group>"; };
+		A20018 /* StatusBarClamshellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarClamshellTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 			children = (
 				A20010 /* NeverdieTests.swift */,
 				A20017 /* ClamshellBatteryTests.swift */,
+				A20018 /* StatusBarClamshellTests.swift */,
 				A20006 /* Neverdie.entitlements */,
 			);
 			name = NeverdieTests;
@@ -256,6 +259,7 @@
 			files = (
 				A10010 /* NeverdieTests.swift in Sources */,
 				A10014 /* ClamshellBatteryTests.swift in Sources */,
+				A10015 /* StatusBarClamshellTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Neverdie/Sources/StatusBarController.swift
+++ b/Neverdie/Sources/StatusBarController.swift
@@ -23,6 +23,12 @@ final class StatusBarController {
     private var errorPulseTimer: Timer?
     private var errorPulseCount: Int = 0
 
+    // MARK: - Clamshell Pause Observation
+    /// Tracks the last known paused state to detect transitions.
+    private var lastKnownPausedState: Bool = false
+    /// Whether state observation is active (can be disabled for testing).
+    private var isObservingState: Bool = false
+
     // MARK: - Init
 
     init(appState: AppState, animationManager: AnimationManager) {
@@ -33,6 +39,7 @@ final class StatusBarController {
         setupButton()
         updateIcon()
         performLaunchFadeIn()
+        startStateObservation()
         logger.info("StatusBarController initialized")
     }
 
@@ -59,6 +66,7 @@ final class StatusBarController {
 
     private func performQuit() {
         logger.info("Quit selected from popover")
+        isObservingState = false
         stopFrameObserver()
         animationManager.stopAnimation()
         appState.cleanup()
@@ -147,6 +155,87 @@ final class StatusBarController {
         frameObserverTimer = nil
     }
 
+    // MARK: - State Observation (Clamshell Pause)
+
+    /// Start observing AppState for `isPausedDueToClamshell` changes using
+    /// `withObservationTracking` (Swift 5.9 Observation framework).
+    private func startStateObservation() {
+        isObservingState = true
+        lastKnownPausedState = appState.isPausedDueToClamshell
+        scheduleObservationTracking()
+    }
+
+    /// Schedules a single observation tracking cycle. When any observed property
+    /// changes, the `onChange` closure fires on the main thread and we re-schedule.
+    private func scheduleObservationTracking() {
+        guard isObservingState else { return }
+        withObservationTracking {
+            // Access properties we want to track — the framework records these.
+            _ = self.appState.isPausedDueToClamshell
+            _ = self.appState.isActive
+        } onChange: { [weak self] in
+            DispatchQueue.main.async {
+                self?.handleStateChange()
+            }
+        }
+    }
+
+    /// Called when observed AppState properties change.
+    private func handleStateChange() {
+        let wasPaused = lastKnownPausedState
+        let isPaused = appState.isPausedDueToClamshell
+
+        if isPaused != wasPaused {
+            lastKnownPausedState = isPaused
+            if isPaused {
+                handleEnterPaused()
+            } else {
+                handleExitPaused()
+            }
+        }
+
+        // Re-schedule for next change
+        scheduleObservationTracking()
+    }
+
+    /// Handle transition into paused state (isPausedDueToClamshell: false -> true).
+    /// Stops animation, shows OFF icon at 50% opacity, fires VoiceOver announcement.
+    private func handleEnterPaused() {
+        stopFrameObserver()
+        animationManager.stopAnimation()
+
+        guard let button = statusItem.button else { return }
+        button.image = animationManager.staticOffIcon
+        button.alphaValue = 0.5
+
+        updateAccessibility()
+        announceStateChange()
+
+        logger.info("StatusBarController: entered paused state (lid closed on battery)")
+    }
+
+    /// Handle transition out of paused state (isPausedDueToClamshell: true -> false).
+    /// If isActive, resumes animation at full opacity. Fires VoiceOver announcement.
+    private func handleExitPaused() {
+        guard let button = statusItem.button else { return }
+
+        if appState.isActive {
+            animationManager.startAnimation()
+            startFrameObserver()
+            button.alphaValue = 1.0
+        }
+        // If not active (user toggled off while paused), don't start animation
+        // but restore opacity
+        if !appState.isActive {
+            button.alphaValue = 1.0
+        }
+
+        updateAccessibility()
+        announceStateChange()
+
+        logger.info("StatusBarController: exited paused state")
+    }
+
     private func updateAnimatedIcon() {
         guard let button = statusItem.button else { return }
         let frame = animationManager.currentFrame
@@ -161,6 +250,14 @@ final class StatusBarController {
 
     func updateIcon() {
         guard let button = statusItem.button else { return }
+
+        // Handle paused state: show OFF icon at 50% opacity
+        if appState.isPausedDueToClamshell {
+            stopErrorPulseAnimation()
+            button.image = animationManager.staticOffIcon
+            button.alphaValue = 0.5
+            return
+        }
 
         if animationManager.isAnimating || animationManager.isPlayingTransition {
             let frame = animationManager.currentFrame
@@ -275,4 +372,22 @@ final class StatusBarController {
     }
 
     var item: NSStatusItem { statusItem }
+
+    // MARK: - Test Helpers
+
+    /// Exposes the current button alpha value for testing.
+    var buttonAlphaValue: CGFloat {
+        statusItem.button?.alphaValue ?? 1.0
+    }
+
+    /// Exposes whether the frame observer timer is active for testing.
+    var isFrameObserverActive: Bool {
+        frameObserverTimer != nil
+    }
+
+    /// Synchronously process a paused state change for testing.
+    /// This bypasses the async observation tracking.
+    func _testHandleStateChange() {
+        handleStateChange()
+    }
 }

--- a/NeverdieTests/StatusBarClamshellTests.swift
+++ b/NeverdieTests/StatusBarClamshellTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Neverdie
+
+/// Tests for StatusBarController reactive updates when isPausedDueToClamshell changes.
+/// Verifies ISSUE-025: icon opacity dimming, animation stop/resume, and accessibility.
+final class StatusBarClamshellTests: XCTestCase {
+
+    private var sleepSpy: SleepManagingSpy!
+    private var clamshell: FakeClamshellObserver!
+    private var power: FakePowerSourceMonitor!
+    private var appState: AppState!
+    private var animationManager: AnimationManager!
+    private var sut: StatusBarController!
+
+    override func setUp() {
+        super.setUp()
+        sleepSpy = SleepManagingSpy()
+        clamshell = FakeClamshellObserver()
+        power = FakePowerSourceMonitor()
+        appState = AppState(
+            sleepManager: sleepSpy,
+            clamshellObserver: clamshell,
+            powerSourceMonitor: power,
+            debounceInterval: 0
+        )
+        appState.startObservers()
+        animationManager = AnimationManager()
+        sut = StatusBarController(appState: appState, animationManager: animationManager)
+    }
+
+    override func tearDown() {
+        appState.cleanup()
+        sut = nil
+        animationManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - AC 1: isPausedDueToClamshell false->true triggers icon stop + opacity 0.5
+
+    func testEnterPaused_stopsAnimationAndDimsOpacity() {
+        // Activate on battery
+        power.simulateTransition(.battery)
+        sut.performToggle()
+        XCTAssertTrue(appState.isActive)
+
+        // Close lid -> paused
+        clamshell.simulateClose()
+        XCTAssertTrue(appState.isPausedDueToClamshell)
+
+        // Synchronously process the state change
+        sut._testHandleStateChange()
+
+        XCTAssertFalse(animationManager.isAnimating, "Animation should stop when paused")
+        XCTAssertEqual(sut.buttonAlphaValue, 0.5, accuracy: 0.01,
+                       "Button alpha should be 0.5 when paused")
+        XCTAssertFalse(sut.isFrameObserverActive, "Frame observer should be stopped when paused")
+    }
+
+    // MARK: - AC 2: isPausedDueToClamshell true->false with isActive==true resumes animation
+
+    func testExitPaused_withActiveTrue_resumesAnimation() {
+        // Activate, go to paused
+        power.simulateTransition(.battery)
+        sut.performToggle()
+        clamshell.simulateClose()
+        sut._testHandleStateChange()
+        XCTAssertTrue(appState.isPausedDueToClamshell)
+
+        // Open lid -> resume
+        clamshell.simulateOpen()
+        XCTAssertFalse(appState.isPausedDueToClamshell)
+        sut._testHandleStateChange()
+
+        XCTAssertTrue(animationManager.isAnimating, "Animation should resume when unpaused")
+        XCTAssertEqual(sut.buttonAlphaValue, 1.0, accuracy: 0.01,
+                       "Button alpha should be 1.0 when resumed")
+        XCTAssertTrue(sut.isFrameObserverActive, "Frame observer should be active when resumed")
+    }
+
+    // MARK: - AC 3: isPausedDueToClamshell true->false with isActive==false does not start animation
+
+    func testExitPaused_withActiveFalse_doesNotStartAnimation() {
+        // Activate, go to paused
+        power.simulateTransition(.battery)
+        sut.performToggle()
+        clamshell.simulateClose()
+        sut._testHandleStateChange()
+
+        // Toggle off while paused
+        appState.toggle()
+        XCTAssertFalse(appState.isActive)
+        XCTAssertFalse(appState.isPausedDueToClamshell) // cleared by toggle off
+
+        sut._testHandleStateChange()
+
+        XCTAssertFalse(animationManager.isAnimating, "Animation should not start when inactive")
+        XCTAssertEqual(sut.buttonAlphaValue, 1.0, accuracy: 0.01,
+                       "Button alpha should be restored to 1.0")
+    }
+
+    // MARK: - updateIcon reflects paused state
+
+    func testUpdateIcon_whenPaused_showsOffIconDimmed() {
+        power.simulateTransition(.battery)
+        sut.performToggle()
+        clamshell.simulateClose()
+        XCTAssertTrue(appState.isPausedDueToClamshell)
+
+        sut.updateIcon()
+
+        XCTAssertEqual(sut.buttonAlphaValue, 0.5, accuracy: 0.01,
+                       "updateIcon should set alpha to 0.5 when paused")
+    }
+}


### PR DESCRIPTION
## Summary
- Wire StatusBarController to observe `isPausedDueToClamshell` changes via `withObservationTracking` (Swift Observation framework)
- When paused: stop animation, show OFF icon at 50% opacity, fire VoiceOver announcement
- When resumed (isActive==true): resume animation, restore opacity, announce
- Add `updateIcon()` paused-state handling for immediate visual feedback

Closes #47

## Test plan
- [x] Unit: isPausedDueToClamshell false->true triggers animation stop + opacity 0.5
- [x] Unit: isPausedDueToClamshell true->false with isActive==true triggers animation resume + opacity 1.0
- [x] Unit: isPausedDueToClamshell true->false with isActive==false does not start animation
- [x] Unit: updateIcon reflects paused state with dimmed opacity
- [x] All 20 existing + new tests pass

Generated with [Claude Code](https://claude.com/claude-code)