### PR TITLE
[ISSUE-029] Replace frameObserverTimer with observation-based frame updates

### DIFF
--- a/Neverdie/Sources/AnimationManager.swift
+++ b/Neverdie/Sources/AnimationManager.swift
@@ -13,55 +13,57 @@ enum AnimationTransition: Equatable, Sendable {
 ///
 /// AnimationManager pre-loads all animation frames from the asset catalog at init,
 /// cycles through them at 6fps via Timer, and provides a `currentFrame` property
-/// for the StatusBarController to observe.
+/// for the StatusBarController to observe via the Observation framework.
 ///
 /// Supports:
 /// - Main loop animation (ON state)
 /// - Transition animations (wake-up, fall-asleep, auto-OFF)
 /// - Reduced motion accessibility (static frame instead of animation)
 /// - Fallback to SF Symbol if assets are missing
+@Observable
 final class AnimationManager {
-    private let logger = Logger.ui
+    @ObservationIgnored private let logger = Logger.ui
 
     // MARK: - Frame Data
 
     /// Main loop frames (ZombieOn_01 through ZombieOn_04).
-    private let loopFrames: [NSImage]
+    @ObservationIgnored private let loopFrames: [NSImage]
 
     /// Wake-up transition frames (ZombieWake_01, ZombieWake_02).
-    private let wakeUpFrames: [NSImage]
+    @ObservationIgnored private let wakeUpFrames: [NSImage]
 
     /// Fall-asleep transition frames (ZombieSleepTrans_01 through ZombieSleepTrans_03).
-    private let fallAsleepFrames: [NSImage]
+    @ObservationIgnored private let fallAsleepFrames: [NSImage]
 
     /// Static OFF icon (sleeping zombie).
-    let staticOffIcon: NSImage
+    @ObservationIgnored let staticOffIcon: NSImage
 
     /// Fallback icon when assets are missing.
-    private let fallbackIcon: NSImage
+    @ObservationIgnored private let fallbackIcon: NSImage
 
     // MARK: - Animation State
 
     /// The current frame to display in the menu bar.
+    /// Observed by StatusBarController to reactively update the icon.
     private(set) var currentFrame: NSImage
 
     /// Timer for frame cycling.
-    private var timer: Timer?
+    @ObservationIgnored private var timer: Timer?
 
     /// Current index in the active frame sequence.
-    private var frameIndex: Int = 0
+    @ObservationIgnored private var frameIndex: Int = 0
 
     /// Whether a transition is currently playing.
     private(set) var isPlayingTransition: Bool = false
 
     /// Frames currently being played (transition or loop).
-    private var activeFrames: [NSImage] = []
+    @ObservationIgnored private var activeFrames: [NSImage] = []
 
     /// Completion handler for the current transition.
-    private var transitionCompletion: (() -> Void)?
+    @ObservationIgnored private var transitionCompletion: (() -> Void)?
 
     /// Frames per second for animation.
-    let fps: Double = 6.0
+    @ObservationIgnored let fps: Double = 6.0
 
     /// Whether the main loop animation is running.
     private(set) var isAnimating: Bool = false
@@ -69,12 +71,12 @@ final class AnimationManager {
     // MARK: - Accessibility
 
     /// Whether reduced motion is enabled.
-    var reducedMotionEnabled: Bool {
+    @ObservationIgnored var reducedMotionEnabled: Bool {
         NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     }
 
     /// Observer token for accessibility changes.
-    private var accessibilityObserver: NSObjectProtocol?
+    @ObservationIgnored private var accessibilityObserver: NSObjectProtocol?
 
     // MARK: - Init
 

--- a/Neverdie/Sources/StatusBarController.swift
+++ b/Neverdie/Sources/StatusBarController.swift
@@ -16,8 +16,8 @@ final class StatusBarController {
     private let logger = Logger.ui
     private var popover: NSPopover?
 
-    /// Timer to observe AnimationManager.currentFrame changes.
-    private var frameObserverTimer: Timer?
+    /// Whether frame observation is active (tracks animationManager.currentFrame).
+    private var isObservingFrames: Bool = false
 
     // MARK: - Error Pulse State
     private var errorPulseTimer: Timer?
@@ -67,7 +67,7 @@ final class StatusBarController {
     private func performQuit() {
         logger.info("Quit selected from popover")
         isObservingState = false
-        stopFrameObserver()
+        stopFrameObservation()
         animationManager.stopAnimation()
         appState.cleanup()
         NSApplication.shared.terminate(nil)
@@ -124,9 +124,9 @@ final class StatusBarController {
             animationManager.playTransition(type: .wakeUp) { [weak self] in
                 self?.animationManager.startAnimation()
             }
-            startFrameObserver()
+            startFrameObservation()
         } else if !appState.isActive && wasActive {
-            stopFrameObserver()
+            stopFrameObservation()
             animationManager.playTransition(type: .fallAsleep) { [weak self] in
                 self?.animationManager.stopAnimation()
                 self?.updateIcon()
@@ -144,19 +144,34 @@ final class StatusBarController {
         logger.info("Toggle triggered, isActive=\(self.appState.isActive)")
     }
 
-    // MARK: - Frame Observer
+    // MARK: - Frame Observation
 
-    private func startFrameObserver() {
-        stopFrameObserver()
-        frameObserverTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / animationManager.fps, repeats: true) { [weak self] _ in
-            self?.updateAnimatedIcon()
-        }
-        frameObserverTimer?.tolerance = 0.05
+    /// Start observing `animationManager.currentFrame` using the Observation framework.
+    /// When `currentFrame` changes, `updateAnimatedIcon()` is called reactively.
+    private func startFrameObservation() {
+        guard !isObservingFrames else { return }
+        isObservingFrames = true
+        scheduleFrameTracking()
     }
 
-    private func stopFrameObserver() {
-        frameObserverTimer?.invalidate()
-        frameObserverTimer = nil
+    /// Stop observing frame changes. The next scheduled tracking cycle will
+    /// see `isObservingFrames == false` and exit.
+    private func stopFrameObservation() {
+        isObservingFrames = false
+    }
+
+    /// Schedules a single observation tracking cycle for `currentFrame`.
+    private func scheduleFrameTracking() {
+        guard isObservingFrames else { return }
+        withObservationTracking {
+            _ = self.animationManager.currentFrame
+        } onChange: { [weak self] in
+            DispatchQueue.main.async {
+                guard let self = self, self.isObservingFrames else { return }
+                self.updateAnimatedIcon()
+                self.scheduleFrameTracking()
+            }
+        }
     }
 
     // MARK: - State Observation (Clamshell Pause)
@@ -221,7 +236,7 @@ final class StatusBarController {
     /// Handle auto-ON: start animation, update icon and accessibility.
     private func handleAutoActivated() {
         animationManager.startAnimation()
-        startFrameObserver()
+        startFrameObservation()
         updateIcon()
         updateAccessibility()
         announceStateChange()
@@ -230,7 +245,7 @@ final class StatusBarController {
 
     /// Handle auto-OFF: stop animation, update icon and accessibility.
     private func handleAutoDeactivated() {
-        stopFrameObserver()
+        stopFrameObservation()
         animationManager.stopAnimation()
         updateIcon()
         updateAccessibility()
@@ -241,7 +256,7 @@ final class StatusBarController {
     /// Handle transition into paused state (isPausedDueToClamshell: false -> true).
     /// Stops animation, shows OFF icon at 50% opacity, fires VoiceOver announcement.
     private func handleEnterPaused() {
-        stopFrameObserver()
+        stopFrameObservation()
         animationManager.stopAnimation()
 
         guard let button = statusItem.button else { return }
@@ -261,7 +276,7 @@ final class StatusBarController {
 
         if appState.isActive {
             animationManager.startAnimation()
-            startFrameObserver()
+            startFrameObservation()
             button.alphaValue = 1.0
         }
         // If not active (user toggled off while paused), don't start animation
@@ -420,9 +435,9 @@ final class StatusBarController {
         statusItem.button?.alphaValue ?? 1.0
     }
 
-    /// Exposes whether the frame observer timer is active for testing.
+    /// Exposes whether frame observation is active for testing.
     var isFrameObserverActive: Bool {
-        frameObserverTimer != nil
+        isObservingFrames
     }
 
     /// Synchronously process a paused state change for testing.

--- a/NeverdieTests/StatusBarClamshellTests.swift
+++ b/NeverdieTests/StatusBarClamshellTests.swift
@@ -98,6 +98,53 @@ final class StatusBarClamshellTests: XCTestCase {
                        "Button alpha should be restored to 1.0")
     }
 
+    // MARK: - ISSUE-029: Observation-based frame updates (no polling timer)
+
+    func testToggleOn_startsFrameObservation() {
+        XCTAssertFalse(sut.isFrameObserverActive, "Frame observation should be inactive when OFF")
+
+        sut.performToggle()
+        XCTAssertTrue(appState.isActive)
+
+        XCTAssertTrue(sut.isFrameObserverActive,
+                      "Frame observation should be active after toggle ON")
+    }
+
+    func testToggleOff_stopsFrameObservation() {
+        sut.performToggle() // ON
+        XCTAssertTrue(sut.isFrameObserverActive)
+
+        sut.performToggle() // OFF
+        XCTAssertFalse(appState.isActive)
+
+        XCTAssertFalse(sut.isFrameObserverActive,
+                       "Frame observation should be inactive after toggle OFF")
+    }
+
+    func testAutoActivated_startsFrameObservation() {
+        // Simulate auto-ON via state change
+        appState.handleProcessUpdate(1)
+        XCTAssertTrue(appState.isActive)
+
+        sut._testHandleStateChange()
+
+        XCTAssertTrue(sut.isFrameObserverActive,
+                      "Frame observation should start on auto-activation")
+    }
+
+    func testAutoDeactivated_stopsFrameObservation() {
+        // Auto-ON then auto-OFF
+        appState.handleProcessUpdate(1)
+        sut._testHandleStateChange()
+        XCTAssertTrue(sut.isFrameObserverActive)
+
+        appState.handleProcessUpdate(0)
+        sut._testHandleStateChange()
+
+        XCTAssertFalse(sut.isFrameObserverActive,
+                       "Frame observation should stop on auto-deactivation")
+    }
+
     // MARK: - updateIcon reflects paused state
 
     func testUpdateIcon_whenPaused_showsOffIconDimmed() {


### PR DESCRIPTION
Closes #53

## Summary
- Make `AnimationManager` `@Observable` with `@ObservationIgnored` on internal properties
- Replace `frameObserverTimer` polling in `StatusBarController` with `withObservationTracking` on `animationManager.currentFrame`
- Remove `startFrameObserver()` / `stopFrameObserver()` methods and all call sites
- Add 4 new tests verifying observation lifecycle

## Test plan
- [x] All tests pass
- [x] 4 new tests cover frame observation start/stop on toggle and auto-activation
- [x] No frame observer timer exists in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)